### PR TITLE
disable firenoc batala

### DIFF
--- a/data/pb/tenant/citymodule.json
+++ b/data/pb/tenant/citymodule.json
@@ -2459,9 +2459,7 @@
         {
           "code": "pb.quadian"
         },
-        {
-          "code": "pb.batala"
-        },
+       
         {
           "code": "pb.testing"
         }


### PR DESCRIPTION
Batala FireNOC is being temporarily disabled till new state wide fire noc fee is not configured 